### PR TITLE
Feature: prettify default_css() output and other tweaks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^.dev$
 ^examples$
 ^\.github$
+^_pkgdown.yml$

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+```
+# Summary
+This branch *<succinct summary of the purpose>*
+
+# Changes
+The changes made in this PR are:
+1. Change 1
+1. Change 2
+...
+
+# Check
+- [ ] All R CMD checks pass 
+- [ ] Check 2
+...
+
+# (OPTIONAL) Note
+This "fixes #<issue_number>"
+
+*<other things, such as how to incorporate new changes>*
+*<brief summary of the purpose of this pull request>*
+```

--- a/R/default_css.R
+++ b/R/default_css.R
@@ -1,12 +1,27 @@
 #' @title Return the default CSS document used in the parallaxr package
 #'
-#' @description This returns a character vector of length 1 containing the default
-#' CSS document used to generate the parallax scroll document.
+#' @description This returns a character vector of length 1 containing the
+#' default CSS document used to generate the parallax scroll document.
+#'
+#' @param path character. Path to where the CSS file should be saved, including
+#' a file name with the ".css" file extension.
+#' Defaults to NULL, where the css will be displayed on the console instead.
+#'
+#' @examples
+#' default_css()
 #'
 #' @export
-default_css <- function(){
+default_css <- function(path = NULL){
 
-  readLines(con = system.file("style.css", package = "parallaxr"), warn = FALSE) %>%
-    paste(collapse = " ")
+  return_css <-
+    readLines(con = system.file("style.css", package = "parallaxr"), warn = FALSE) %>%
+    paste(collapse = "\n")
 
+  if(is.null(path)){
+    message(return_css)
+
+  } else {
+
+    writeLines(return_css, con = path)
+  }
 }

--- a/README.md
+++ b/README.md
@@ -40,4 +40,17 @@ More documentation is available for the individual functions, e.g.
 ?generate_scroll_doc
 ```
 
+You may also visit https://martinctc.github.io/parallaxr/reference.
+
+## Examples
+
+Further examples and use cases can be found below:
+
+- https://frankpopham.github.io/side/ (@frankpopham)
+- https://durraniu.github.io/BBC100/ (@durranniu)
+
+Thank you all who have contributed examples! If you would like to add your example to this list, please fork this repo and create a pull request to edit this README page.
+
+## Getting involved
+
 If you have any questions, bugs, or suggestions for enhancements, please log an issue with https://github.com/martinctc/parallaxr/issues. This is an open-source project, so any contribution is very welcome! Pull requests are welcome. 

--- a/man/default_css.Rd
+++ b/man/default_css.Rd
@@ -4,9 +4,18 @@
 \alias{default_css}
 \title{Return the default CSS document used in the parallaxr package}
 \usage{
-default_css()
+default_css(path = NULL)
+}
+\arguments{
+\item{path}{character. Path to where the CSS file should be saved, including
+a file name with the ".css" file extension.
+Defaults to NULL, where the css will be displayed on the console instead.}
 }
 \description{
-This returns a character vector of length 1 containing the default
-CSS document used to generate the parallax scroll document.
+This returns a character vector of length 1 containing the
+default CSS document used to generate the parallax scroll document.
+}
+\examples{
+default_css()
+
 }


### PR DESCRIPTION
# Summary
This branch introduces some minor improvements to the package/ repo, including the improvement of the css returned by `default_css()`.

# Changes
The changes made in this PR are:
1. Improve the formatting returned by `default_css()`.
1. Add a pull request template to `.github`.
1. Add user examples to README.
...

# Check
- [x] All R CMD checks pass 
...

# Note

This fixes #4 and #6. 

Special thanks to @frankpopham and @durranniu for contributing user examples.